### PR TITLE
Remove package list after a build

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v0.1.1
+------
+
+*Unreleased*
+
+- Add list of packages to remove after build. [azman0101]
+
 v0.1.0
 ------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -138,6 +138,9 @@ backporter_sdk_packages: [ 'devscripts', 'build-essential', 'debian-keyring',
                            'liburi-perl', 'libdistro-info-perl', 'python-httplib2',
                            'curl', 'debhelper' ]
 
+# List of required Debian SDK packages to install on a host before backporting
+backporter_sdk_packages_remove_after: [ 'devscripts', 'build-essential' ]
+
 # List of source repositories to enable on a host
 backporter_repositories:
   - 'deb-src {{ backporter_build_mirror }} {{ ansible_distribution_release }} main contrib'

--- a/tasks/backport_package.yml
+++ b/tasks/backport_package.yml
@@ -166,11 +166,7 @@
   with_flattened:
     - '{{ backporter_sdk_packages_remove_after }}'
 
-- name: Check if packages need to be autoremoved
-  command: apt-get --dry-run autoremove
-  register: check_autoremove
-  changed_when: False
-
 - name: Autoremove unused packages
   command: apt-get -y autoremove
-  when: "'packages will be REMOVED' in check_autoremove.stdout"
+  register: autoremove_output
+  changed_when: "'The following packages will be REMOVED' in autoremove_output.stdout"

--- a/tasks/backport_package.yml
+++ b/tasks/backport_package.yml
@@ -161,3 +161,16 @@
   when: (backporter_register_built_packages_uploaded is defined and backporter_register_built_packages_uploaded.changed) and
         (backporter_mail_to is defined and backporter_mail_to)
 
+- name: Remove packages no more required
+  apt: pkg={{ item }} state=absent purge=yes
+  with_flattened:
+    - '{{ backporter_sdk_packages_remove_after }}'
+
+- name: Check if packages need to be autoremoved
+  command: apt-get --dry-run autoremove
+  register: check_autoremove
+  changed_when: False
+
+- name: Autoremove unused packages
+  command: apt-get -y autoremove
+  when: "'packages will be REMOVED' in check_autoremove.stdout"


### PR DESCRIPTION
For security reason, is it not safer to remove some packages after build (compilers for example) ?
